### PR TITLE
Fix FCM Token Fetch Error.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "cordova-plugin-fcm",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.6",
+  "version": "2.1.7",
   "name": "hrs-cordova-plugin-fcm",
   "cordova_name": "Cordova FCM Push Plugin",
   "description": "Google Firebase Cloud Messaging Cordova Push Plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -19,14 +19,14 @@
 -->
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="hrs-cordova-plugin-fcm"
-      version="2.1.6">
+      version="2.1.7">
     <name>FCMPlugin</name>
     <description>Cordova FCM Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova, fcm, push, plugin</keywords>
 
     <info>
-		Cordova FCM plugin v2.1.6 installed
+		Cordova FCM plugin v2.1.7 installed
 		For more details visit https://github.com/bpowell15/hrs-cordova-plugin-fcm
 	</info>
 

--- a/src/android/FCMPlugin.java
+++ b/src/android/FCMPlugin.java
@@ -19,6 +19,8 @@ import android.os.Bundle;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+import com.google.android.gms.tasks.OnSuccessListener;
 
 
 import java.util.Map;
@@ -75,13 +77,18 @@ public class FCMPlugin extends CordovaPlugin {
 				cordova.getThreadPool().execute(new Runnable() {
 					public void run() {
 						try{
-							String token = FirebaseInstanceId.getInstance().getToken();
-							callbackContext.success( FirebaseInstanceId.getInstance().getToken() );
-							Log.d(TAG,"\tToken: "+ token);
-							createDefaultChannel();
+							FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener( cordova.getActivity(), new OnSuccessListener<InstanceIdResult>() {
+                                    @Override
+                                    public void onSuccess(InstanceIdResult instanceIdResult) {
+                                          String token = instanceIdResult.getToken();
+                                          callbackContext.success( token );
+                                          Log.d(TAG,"\tToken: "+ token);
+                                    }
+                            });
 						}catch(Exception e){
 							Log.d(TAG,"\tError retrieving token");
 						}
+						createDefaultChannel();
 					}
 				});
 			}


### PR DESCRIPTION
FirebaseInstanceId.getInstance() is deprecated and could not successfully get the FCM Token. Switching to the suggested getInstanceId() method instead, as per FCM documentation: https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#getToken().